### PR TITLE
style: fix a lint error in converter

### DIFF
--- a/src/converter/ni_measurement_plugin_converter/__init__.py
+++ b/src/converter/ni_measurement_plugin_converter/__init__.py
@@ -65,9 +65,7 @@ MEASUREMENT_VERSION = "1.0.0.0"
 
 MEASUREMENT_FILE_PATH_OPTION = "--measurement-file-path"
 
-INVALID_FILE_DIR = (
-    "Invalid measurement file path. Please provide valid measurement file path."
-)
+INVALID_FILE_DIR = "Invalid measurement file path. Please provide valid measurement file path."
 FUNCTION_NOT_FOUND = "Measurement function {function} not found in the file {measurement_file_path}"
 
 


### PR DESCRIPTION
<!-- TODO: Mark the following with an 'x' as applicable -->
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-plugin-converter-python/blob/main/CONTRIBUTING.md). _(Required)_

### What does this Pull Request accomplish?
#46 updated the converter's `__init__.py`'s `INVALID_FILE_DIR` string literal by replacing the text "directory" with "path," which reduced the total character length from 105 to 95, leading to a lint error. This PR fixes it by removing the now redundant braces `()`.

### Why should this Pull Request be merged?
To ensure that the repo files don't produce any lint errors for future contributors.

### What testing has been done?
NA. Just formatting changes.

### Checklist

- [ ] Code follows coding standards
- [ ] No console logs or debug statements
- [ ] Manual tests conducted
- [ ] Doesn’t break existing functionality
- [ ] Documentation updated (if applicable)
- [ ] No performance regressions (if applicable)
- [ ] Tests have been written/updated (if applicable)